### PR TITLE
fix example for sdfRequired

### DIFF
--- a/sdf.md
+++ b/sdf.md
@@ -716,7 +716,7 @@ instance conforming the current definition.
 The value of "sdfRequired" is an array of JSON pointers, each
 indicating one declaration that is mandatory to be represented.
 
-The example in {{example-req}} shows two required elements in the sdfObject definition for "temperatureWithAlarm", the sdfProperty "temperatureData", and the sdfEvent "overTemperatureEvent". The example also shows the use of JSON pointer with "sdfRef" to use a pre-existing definition in this definition, for the "alarmType" data (sdfOutputData) produced by the sdfEvent "overTemperatureEvent".
+The example in {{example-req}} shows two required elements in the sdfObject definition for "temperatureWithAlarm", the sdfProperty "currentTemperature", and the sdfEvent "overTemperatureEvent". The example also shows the use of JSON pointer with "sdfRef" to use a pre-existing definition in this definition, for the "alarmType" data (sdfOutputData) produced by the sdfEvent "overTemperatureEvent".
 
 ~~~ json
 {

--- a/sdf.md
+++ b/sdf.md
@@ -723,12 +723,17 @@ The example in {{example-req}} shows two required elements in the sdfObject defi
   "sdfObject": {
     "temperatureWithAlarm": {
       "sdfRequired": [
-        "#/sdfObject/temperatureWithAlarm/sdfData/temperatureData",
+        "#/sdfObject/temperatureWithAlarm/sdfProperty/currentTemperature",
         "#/sdfObject/temperatureWithAlarm/sdfEvent/overTemperatureEvent"
       ],
       "sdfData":{
         "temperatureData": {
           "type": "number"
+        }
+      },
+      "sdfProperty": {
+        "currentTemperature": {
+          "sdfRef": "#/sdfObject/temperatureWithAlarm/sdfData/temperatureData"
         }
       },
       "sdfEvent": {


### PR DESCRIPTION
Example for sdfRequired should not point to sdfData, but to an sdfProperty definition. Added an appropriate sdfProperty definition and changed the pointer.