### PR TITLE
Improved sdfRef semantic breadcrumb with sdfRefFrom

### DIFF
--- a/sdf-framework.cddl
+++ b/sdf-framework.cddl
@@ -34,7 +34,8 @@ commonqualities = (
  ? description: text            ; long text (no constraints)
  ? label: text                  ; short text (no constraints); default to key
  ? $comment: text               ; source code comments only, no semantics
- ? sdfRef: sdf-pointer
+ ? (sdfRef: sdf-pointer //
+    sdfRefFrom: sdf-pointer)
  ? sdfRequired: pointer-list    ; applies to qualities of properties, of data
 )
 
@@ -145,7 +146,8 @@ jsonschema = (
  ? uniqueItems: bool
  ? items: { ;;; ultimately, this will be mostly recursive, but, for now
             ;;; let's find out what we actually need
-     ? sdfRef: sdf-pointer          ; import limited to the subset that we allow here...
+     ? (sdfRef: sdf-pointer //      ; import limited to the subset that we allow here...
+        sdfRefFrom: sdf-pointer)
      ? description: text            ; long text (no constraints)
      ? $comment: text               ; source code comments only, no semantics
      ; commonqualities, ; -- ISSUE: should leave this out for non-complex data types, but need the above three

--- a/sdf.md
+++ b/sdf.md
@@ -698,7 +698,7 @@ Name references occur only in specific elements of the syntax of SDF:
 * pointing to elements via sdfRequired value elements
 
 
-## sdfRef
+## sdfRef {#sdfref}
 
 In a JSON map establishing a definition, the keyword "sdfRef" is used
 to copy all of the qualities and enclosed definitions of the referenced definition, indicated
@@ -723,6 +723,8 @@ The sdfRef keyword also indicates a relationship to the referenced definition: t
 For example, if the referenced definition is a "coordinate" type with unit of meters and description of how the value refers to a common reference point, a set of X, Y, and Z coordinate properties could be created with sdfRef based on that definition which all share those semantics but get separate definitions.
 
 When sdfRef is processed, the keyword is renamed to sdfRefFrom to keep the information about the relationship between definitions but to avoid potential subsequent processing steps attempting to copy the referenced qualities and definitions again.
+When processing sdfRef, if the target definition contains sdfRef (i.e., is based on yet another definition), that MUST be processed before processing the first target definition.
+If the target definition contains sdfRefFrom (i.e., was based on another definition that has been already processed), the sdfRefFrom MUST NOT be copied.
 
 More formally, for a JSON map that contains an
 sdfRef member, the semantics is defined to be as if the following steps were performed:
@@ -740,7 +742,47 @@ sdfRef member, the semantics is defined to be as if the following steps were per
 TODO: Make sure that the grammar in {{syntax}} allows specifying the
 null values that are necessary to remove members in a merge-patch.
 
-A model where all sdfRef references are processed as described above is called a resolved model.
+### Resolved models
+
+A model where all sdfRef references are processed as described in {{sdfref}} is called a resolved model.
+
+For example, given the following sdfData definitions:
+
+~~~ json
+"sdfData": {
+  "Coordinate" : {
+    "type": "number", "unit": "m"
+  },
+  "X-Coordinate" : {
+    "sdfRef" : "#/sdfData/Coordinate",
+    "description": "Distance from the base of the Thing along the X axis."
+  },
+  "Pos-X-Coordinate" : {
+    "sdfRef": "#/sdfData/X-Coordinate",
+    "minimum": 0
+  }
+}
+~~~
+
+After resolving the definitions would look as follows:
+
+~~~ json
+"sdfData": {
+  "Coordinate" : {
+    "type": "number", "unit": "m"
+  },
+  "X-Coordinate" : {
+    "sdfRefFrom" : "#/sdfData/Coordinate",
+    "description": "Distance from the base of the Thing along the X axis.",
+    "type": "number", "unit": "m"
+  },
+  "Pos-X-Coordinate" : {
+    "sdfRefFrom": "#/sdfData/X-Coordinate",
+    "description": "Distance from the base of the Thing along the X axis.",
+    "minimum": 0, "type": "number", "unit": "m"
+  }
+}
+~~~
 
 ## sdfRequired
 

--- a/sdf.md
+++ b/sdf.md
@@ -719,6 +719,9 @@ The sdfRef member need not be the only member of a map.
 Additional members may be present with the intention to override parts
 of the referenced map or to add new qualities or definitions.
 
+The sdfRef keyword also indicates a relationship to the referenced definition: the semantics of the new definition are based on the semantics of the referenced definition.
+For example, if the referenced definition is a "coordinate" type with unit of meters and description of how the value refers to a common reference point, a set of X, Y, and Z coordinate properties could be created with sdfRef based on that definition which all share those semantics but get separate definitions.
+
 More formally, for a JSON map that contains an
 sdfRef member, the semantics is defined to be as if the following steps were performed:
 

--- a/sdf.md
+++ b/sdf.md
@@ -701,7 +701,7 @@ Name references occur only in specific elements of the syntax of SDF:
 ## sdfRef
 
 In a JSON map establishing a definition, the keyword "sdfRef" is used
-to copy all of the qualities of the referenced definition, indicated
+to copy all of the qualities and enclosed definitions of the referenced definition, indicated
 by the included name reference, into the newly formed definition.
 (This can be compared to the processing of the "$ref" keyword in {{-jso}}.)
 
@@ -717,7 +717,8 @@ creates a new definition "temperatureProperty" that contains all of the qualitie
 
 The sdfRef member need not be the only member of a map.
 Additional members may be present with the intention to override parts
-of the referenced map.
+of the referenced map or to add new qualities or definitions.
+
 More formally, for a JSON map that contains an
 sdfRef member, the semantics is defined to be as if the following steps were performed:
 

--- a/sdf.md
+++ b/sdf.md
@@ -722,12 +722,14 @@ of the referenced map or to add new qualities or definitions.
 The sdfRef keyword also indicates a relationship to the referenced definition: the semantics of the new definition are based on the semantics of the referenced definition.
 For example, if the referenced definition is a "coordinate" type with unit of meters and description of how the value refers to a common reference point, a set of X, Y, and Z coordinate properties could be created with sdfRef based on that definition which all share those semantics but get separate definitions.
 
+When sdfRef is processed, the keyword is renamed to sdfRefFrom to keep the information about the relationship between definitions but to avoid potential subsequent processing steps attempting to copy the referenced qualities and definitions again.
+
 More formally, for a JSON map that contains an
 sdfRef member, the semantics is defined to be as if the following steps were performed:
 
 1. The JSON map that contains the sdfRef member is copied into a
    variable named "patch".
-2. The sdfRef member of the copy in "patch" is removed.
+2. The sdfRef member of the copy in "patch" is renamed to "sdfRefFrom".
 3. the JSON pointer that is the value of the sdfRef member is
    dereferenced and the result is copied into a variable named "original".
 4. The JSON Merge Patch algorithm {{-merge-patch}} is applied to patch

--- a/sdf.md
+++ b/sdf.md
@@ -740,6 +740,8 @@ sdfRef member, the semantics is defined to be as if the following steps were per
 TODO: Make sure that the grammar in {{syntax}} allows specifying the
 null values that are necessary to remove members in a merge-patch.
 
+A model where all sdfRef references are processed as described above is called a resolved model.
+
 ## sdfRequired
 
 The keyword "sdfRequired" is provided to apply a constraint that


### PR DESCRIPTION
Clarified use of `sdfRef` and added new keyword `sdfRefFrom` to indicate where the referenced information came from after processing the reference.