### PR TITLE
Make entries of info block optional

### DIFF
--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -15,10 +15,10 @@ sdf-syntax = {
 }
 
 sdfinfo = {
- title: text
- version: text
- copyright: text
- license: text
+ ? title: text
+ ? version: text
+ ? copyright: text
+ ? license: text
  EXTENSION-POINT<"info-ext">
 }
 

--- a/sdf.md
+++ b/sdf.md
@@ -535,10 +535,10 @@ Qualities of the information block are shown in {{infoblockqual}}.
 
 | Quality   | Type   | Required | Description                                                 |
 |-----------|--------|----------|-------------------------------------------------------------|
-| title     | string | yes      | A short summary to be displayed in search results, etc.     |
-| version   | string | yes      | The incremental version of the definition, format TBD       |
-| copyright | string | yes      | Link to text or embedded text containing a copyright notice |
-| license   | string | yes      | Link to text or embedded text containing license terms      |
+| title     | string | no       | A short summary to be displayed in search results, etc.     |
+| version   | string | no       | The incremental version of the definition, format TBD       |
+| copyright | string | no       | Link to text or embedded text containing a copyright notice |
+| license   | string | no       | Link to text or embedded text containing license terms      |
 {: #infoblockqual title="Qualities of the Information Block"}
 
 While the format of the version string is marked as TBD, it is intended to be lexicographically increasing over the life of a model: a newer model always has a version string that string-compares higher than all previous versions.


### PR DESCRIPTION
At the moment, the members of the information block are declared mandatory although they are intended to be optional. This PR introduces minor changes to the draft and the CDDL schemas to reflect this intention.