### PR TITLE
Structured sdfInputData & sdfOutputData

### DIFF
--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -68,9 +68,9 @@ parameter-list =
 
 actionqualities = {
  commonqualities,
- ? sdfInputData: parameter-list   ; sdfRequiredInputData applies here (a bit redundant)
+ ? sdfInputData: named<dataqualities>    ; zero or more named data type definitions
  ? ("sdfRequiredInputData" .feature "1.0") => pointer-list
- ? sdfOutputData: parameter-list  ; sdfRequired applies here
+ ? sdfOutputData: named<dataqualities>   ; zero or more named data type definitions
  ? sdfData: named<dataqualities>         ; zero or more named data type definitions that might be used in the above
  EXTENSION-POINT<"action-ext">
 }

--- a/sdf.md
+++ b/sdf.md
@@ -1066,8 +1066,7 @@ The qualities of an Action definition include the common qualities, additional q
 
 `sdfInputData` defines the input data of the action.  `sdfOutputData`
 defines the output data of the action.
-
-TBD: indicating optionality
+`sdfRequired` can be used to indicate mandatory input and/or output parameters.
 
 ## sdfEvent
 
@@ -1080,14 +1079,13 @@ The qualities of sdfEvent include the common qualities, additional qualities are
 | Quality       | Type      | Description                                                              |
 |---------------+-----------+--------------------------------------------------------------------------|
 | (common)      |           | {{common-qualities}}                                                     |
-| sdfOutputData | map       | data qualities of the output data for an Event                           |
+| sdfOutputData | named-sdq | zero or more named data type definitions of the output data for an Event |
 | sdfData       | named-sdq | zero or more named data type definitions that might be used in the above |
 {: #sdfevqual title="Qualities of sdfEvent"}
 
 `sdfOutputData` defines the output data of the action.
-As discussed in {{sdfevent-overview}}, a set of data qualities with
-type "object" can be used to substructure the output data item, with
-optionality indicated by the data quality `required`.
+`sdfRequired` can be used to indicate mandatory output parameters.
+
 
 ## sdfData
 

--- a/sdf.md
+++ b/sdf.md
@@ -433,10 +433,8 @@ state, often resulting in some outward physical effect (which, itself,
 cannot be modeled in SDF).  From a programmer's perspective, they
 might be considered to be roughly analogous to method calls.
 
-Actions may have data parameters; these are modeled as a single item of input
-data and output data, each.  (Where multiple parameters need to be
-modeled, an "object" type can be used to combine these parameters into one.)
-<!-- (using `sdfData` definitions, i.e., the same entries as for `sdfProperty` declarations). -->
+Actions may have data parameters; these are modeled as a set of named input
+data and output data definitions.
 Actions may be long-running, that is to say that the effects may not
 take place immediately as would be expected for an update to an
 `sdfProperty`; the effects may play out over time and emit action
@@ -784,15 +782,12 @@ The example in {{example-req}} shows two required elements in the sdfObject defi
       "sdfEvent": {
         "overTemperatureEvent": {
           "sdfOutputData": {
-            "type": "object",
-            "properties": {
-              "alarmType": {
-                "sdfRef": "cap:#/sdfData/alarmTypes/quantityAlarms",
-                "const": "OverTemperatureAlarm"
-              },
-              "temperature": {
-                "sdfRef": "#/sdfObject/temperatureWithAlarm/sdfData/temperatureData"
-              }
+            "alarmType": {
+              "sdfRef": "cap:#/sdfData/alarmTypes/quantityAlarms",
+              "const": "OverTemperatureAlarm"
+            },
+            "temperature": {
+              "sdfRef": "#/sdfObject/temperatureWithAlarm/sdfData/temperatureData"
             }
           }
         }
@@ -1064,16 +1059,15 @@ The qualities of an Action definition include the common qualities, additional q
 | Quality       | Type      | Description                                                              |
 |---------------+-----------+--------------------------------------------------------------------------|
 | (common)      |           | {{common-qualities}}                                                     |
-| sdfInputData  | map       | data qualities of the input data for an Action                           |
-| sdfOutputData | map       | data qualities of the output data for an Action                          |
+| sdfInputData  | named-sdq | zero or more named data type definitions for input data for an Action    |
+| sdfOutputData | named-sdq | zero or more named data type definitions of the output data for an Action|
 | sdfData       | named-sdq | zero or more named data type definitions that might be used in the above |
 {: #sdfactqual title="Qualities of sdfAction"}
 
 `sdfInputData` defines the input data of the action.  `sdfOutputData`
 defines the output data of the action.
-As discussed in {{sdfaction-overview}}, a set of data qualities with
-type "object" can be used to substructure either data item, with
-optionality indicated by the data quality `required`.
+
+TBD: indicating optionality
 
 ## sdfEvent
 


### PR DESCRIPTION
This PR suggests to change the single input/output parameter to a set of SDF definitions similar to sdfProperty and sdfData definition blocks.

Currently sdfInputData and sdfOutputData support only one data element definition. For more complex input/output parameters the spec suggested to use a JSON object as the data element. With the single element the parameters don't get SDF names that could be referred to by applications (at SDF level it's always just a single parameter). Also this results sometimes in more complex definitions (e.g., 9 lines instead of 6 lines in the example updated in this PR for two output data elements). 

Downside of this structured approach is that one needs to use sdfRequired to indicate optionality that is slightly more verbose than using the JSO required keyword. Perhaps could consider here a different default behavior than all optional? Also for output data a single value is likely to be the most common case where this structured approach adds a bit overhead (you need to name even the single element).