### PR TITLE
align CDDL comma usage

### DIFF
--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -40,7 +40,7 @@ commonqualities = (
 
 ; for building hierarchy
 thingqualities = {
- commonqualities,
+ commonqualities
  ? sdfObject: named<objectqualities>
  ? sdfThing: named<thingqualities>
  EXTENSION-POINT<"thing-ext">
@@ -50,7 +50,7 @@ productqualities = thingqualities ; ISSUE: get rid of sdfProduct?
 
 ; for single objects, or for arrays of objects (1.2)
 objectqualities = {
- commonqualities,
+ commonqualities
  ? ("minItems" .feature "1.2") => number
  ? ("maxItems" .feature "1.2") => number
  ? sdfProperty: named<propertyqualities>
@@ -67,7 +67,7 @@ parameter-list =
   dataqualities .feature (["1.1", "dataqualities-as-parameter"])
 
 actionqualities = {
- commonqualities,
+ commonqualities
  ? sdfInputData: parameter-list   ; sdfRequiredInputData applies here (a bit redundant)
  ? ("sdfRequiredInputData" .feature "1.0") => pointer-list
  ? sdfOutputData: parameter-list  ; sdfRequired applies here
@@ -83,8 +83,8 @@ eventqualities = {
 }
 
 dataqualities = {               ; also propertyqualities
- commonqualities,
- jsonschema,
+ commonqualities
+ jsonschema
  ? ("units" .feature "1.0") => text
  ? ("unit" .feature "1.1") => text
  ? ("scaleMinimum" .feature "1.0") => number
@@ -107,9 +107,9 @@ allowed-types = number / text / bool / null
               / (any .feature "allowed-ext")                     ; EXTENSION-POINT
 
 compound-type = (
-  "type" => ("object" .feature "1.1"),
-  ? required: [+text],
-  ? properties: named<dataqualities>,
+  "type" => ("object" .feature "1.1")
+  ? required: [+text]
+  ? properties: named<dataqualities>
 )
 
 choice-type = (


### PR DESCRIPTION
This PR proposes some minor adjustments to the CDDL schemas for a consistent style by removing unnecessary commas.

If this PR gets merged, it resolves #44.