### PR TITLE
Using $ref instead of sdfRef in JSO example

### DIFF
--- a/sdf.md
+++ b/sdf.md
@@ -979,9 +979,9 @@ sdfChoice merges the functions of two constructs found in {{-jso}}:
   ~~~ json
   "anyOf": [
     {"type": "array", "minItems": 3, "maxItems": "3", "items": {
-       "sdfRef": "#/sdfData/rgbVal"}},
+       "$ref": "#/sdfData/rgbVal"}},
     {"type": "array", "minItems": 4, "maxItems": "4", "items": {
-       "sdfRef": "#/sdfData/cmykVal"}}
+       "$ref": "#/sdfData/cmykVal"}}
   ]
   ~~~
 


### PR DESCRIPTION
Given the example refers to "how things would look like in JSO", seems that using JSO `$ref` instead of `sdfRef` makes sense.