### PR TITLE
Move readable, writable, and observable to `sdfProperty`

### DIFF
--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -60,8 +60,6 @@ objectqualities = {
  EXTENSION-POINT<"object-ext">
 }
 
-propertyqualities = dataqualities ; the definitions in sdfData are declarations in sdfProperty
-
 parameter-list =
   pointer-list .feature (["1.0", "pointerlist-as-parameter"]) /
   dataqualities .feature (["1.1", "dataqualities-as-parameter"])
@@ -82,16 +80,13 @@ eventqualities = {
  EXTENSION-POINT<"event-ext">
 }
 
-dataqualities = {               ; also propertyqualities
+dataqualities = {
  commonqualities
  jsonschema
  ? ("units" .feature "1.0") => text
  ? ("unit" .feature "1.1") => text
  ? ("scaleMinimum" .feature "1.0") => number
  ? ("scaleMaximum" .feature "1.0") => number
- ? observable: bool
- ? readable: bool
- ? writable: bool
  ? nullable: bool
  ? ("subtype" .feature "1.0") => "byte-string" / "unix-time"
             / (text .feature "subtype-ext")                       ; EXTENSION-POINT
@@ -99,6 +94,13 @@ dataqualities = {               ; also propertyqualities
             / (text .feature "sdftype-ext")                       ; EXTENSION-POINT
  ? contentFormat: text
  EXTENSION-POINT<"data-ext">
+}
+
+propertyqualities = {
+ dataqualities
+ ? observable: bool
+ ? readable: bool
+ ? writable: bool
 }
 
 allowed-types = number / text / bool / null

--- a/sdf.md
+++ b/sdf.md
@@ -402,10 +402,7 @@ changes.
 (These three aspects are described by the qualities `readable`,
 `writable`, and `observable` defined for an `sdfProperty`.)
 
-Definitions in `sdfProperty` groups look like definitions in `sdfData` groups, however, they actually also declare a Property with the given qualities to be potentially present in the containing Object.
-(Qualities beyond those of `sdfData` definitions could be defined for `sdfProperty` declarations
-but currently aren't; this means that even Property qualities
-such as `readable` and `writable` can be associated with definitions in `sdfData` groups, as well.)
+Definitions in `sdfProperty` groups include the definitions from `sdfData` groups, however, they actually also declare a Property with the given qualities to be potentially present in the containing Object.
 
 For definitions in `sdfProperty` and `sdfData`, SDF provides qualities that can
 constrain the structure and values of data allowed in an instance of
@@ -847,15 +844,12 @@ present specification.
 | unit          | string                                    | unit name (note 1)                                              | N/A     |
 | scaleMinimum  | number                                    | lower limit of value in units given by unit (note 2)            | N/A     |
 | scaleMaximum  | number                                    | upper limit of value in units given by unit (note 2)            | N/A     |
-| readable      | boolean                                   | Reads are allowed                                               | true    |
-| writable      | boolean                                   | Writes are allowed                                              | true    |
-| observable    | boolean                                   | flag to indicate asynchronous notification is available         | true    |
 | nullable      | boolean                                   | indicates a null value is available for this type               | true    |
 | contentFormat | string                                    | content type (IANA media type string plus parameters), encoding | N/A     |
 | sdfType       | string ({{sdftype}})                        | sdfType enumeration (extensible)                                | N/A     |
 | sdfChoice     | named set of data qualities ({{sdfchoice}}) | named alternatives                                              | N/A     |
 | enum          | array of strings                          | abbreviation for string-valued named alternatives               | N/A     |
-{: #sdfdataqual2 title="SDF-defined Qualities of sdfProperty and sdfData"}
+{: #sdfdataqual2 title="SDF-defined Qualities of sdfData"}
 
 
 1. Note that the quality `unit` was called `units` in SDF 1.0.
@@ -1056,7 +1050,15 @@ The sdfProperty keyword denotes a group of zero or more Property definitions.
 Properties are used to model elements of state.
 
 The qualities of a Property definition include the data qualities (and
-thus the common qualities), see {{data-qualities}}.
+thus the common qualities), see {{data-qualities}}, additional qualities are shown in {{sdfpropqual}}.
+
+| Quality       | Type      | Description                                             | Default |
+|---------------+-----------+---------------------------------------------------------|---------|
+| (data)        |           | {{data-qualities}}                                      |         |
+| readable      | boolean   | Reads are allowed                                       | true    |
+| writable      | boolean   | Writes are allowed                                      | true    |
+| observable    | boolean   | flag to indicate asynchronous notification is available | true    |
+{: #sdfpropqual title="Qualities of sdfProperty"}
 
 ## sdfAction
 


### PR DESCRIPTION
This PR is a follow-up to #52 and moves the readable, writable, and observable qualities to `sdfProperty`, making it an extension rather than an alias of `sdfData`.

If I interpreted the minutes of the [last interim meeting](https://github.com/ietf-wg-asdf/asdf-working-group-notes/blob/main/meetings/minutes20220117.md#pr-52-dataqualities-rwo) correctly, this also reflects the decision that has been made there. However, the documentation of potential downsides is probably something that still needs to be added.

Resolves #52.