### PR TITLE
Clarifying current use of the version field

### DIFF
--- a/sdf.md
+++ b/sdf.md
@@ -525,13 +525,16 @@ Qualities of the information block are shown in {{infoblockqual}}.
 | Quality   | Type   | Required | Description                                                 |
 |-----------|--------|----------|-------------------------------------------------------------|
 | title     | string | no       | A short summary to be displayed in search results, etc.     |
-| version   | string | no       | The incremental version of the definition, format TBD       |
+| version   | string | no       | The incremental version of the definition                   |
 | copyright | string | no       | Link to text or embedded text containing a copyright notice |
 | license   | string | no       | Link to text or embedded text containing license terms      |
 {: #infoblockqual title="Qualities of the Information Block"}
 
-While the format of the version string is marked as TBD, it is intended to be lexicographically increasing over the life of a model: a newer model always has a version string that string-compares higher than all previous versions.
+The version quality is used to indicate version information about the set of definitions in the file.
+The version is RECOMMENDED to be lexicographically increasing over the life of a model: a newer model always has a version string that string-compares higher than all previous versions.
 This is easily achieved by following the convention to start the version with an {{RFC3339}} `date-time` or, if new versions are generated less frequently than once a day, just the `full-date` (i.e., YYYY-MM-DD); in many cases, that will be all that is needed (see {{example1}} for an example).
+This specification does not give a strict definition for the format of the version string but each using system or organization should define internal structure and semantics to the level needed for their use.
+If no further details are provided, a `date-time` or `full-date` in this field can be assumed to indicate the latest update time of the definitions in the file.
 
 The license string is preferably either a URI that points to a web page with an unambiguous definition of the license, or an {{SPDX}} license identifier.
 (For models to be handled by the One Data Model liaison group, this will typically be "BSD-3-Clause".)


### PR DESCRIPTION
This PR attempts to clarify how the version field is currently used, removing the TBDs. Alternatively, we could add more detailed definition as discussed in issue #29 