### PR TITLE
Align sdfThing and sdfObject

### DIFF
--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -6,8 +6,7 @@ sdf-syntax = {
  ? defaultNamespace: text
  ? sdfThing: named<thingqualities>       ; Thing is a composition of objects that work together in some way
  ? sdfObject: named<objectqualities>     ; Object is a set of Properties, Actions, and Events that together perform a particular function
- affordancequalities                     ; Includes Properties, Actions, and Events
- ? sdfData: named<dataqualities>         ; Data represents a piece of information that can be the state of a property or a parameter to an action or a signal in an event
+ affordancequalities                     ; Includes Properties, Actions, and Events as well as sdfData
  EXTENSION-POINT<"top-ext">
 }
 
@@ -44,6 +43,8 @@ affordancequalities = {
  ? sdfProperty: named<propertyqualities> ; Property represents the state of an instance of an object
  ? sdfAction: named<actionqualities>     ; Action is a directive to invoke an application layer verb associated with an object
  ? sdfEvent: named<eventqualities>       ; Event represents an occurrence of something associated with an object
+ ? sdfData: named<dataqualities>         ; Data represents a piece of information that can be the
+                                         ; state of a property or a parameter to an action or a signal in an event
 }
 
 ; for building hierarchy

--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -35,8 +35,8 @@ commonqualities = (
 )
 
 arraydefinitionqualities = (
- ? ("minItems" .feature "1.2") => number
- ? ("maxItems" .feature "1.2") => number
+ ? ("minItems" .feature "1.2") => uint
+ ? ("maxItems" .feature "1.2") => uint
 )
 
 affordancequalities = (

--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -61,6 +61,7 @@ objectqualities = {
  commonqualities
  affordancequalities
  arraydefinitionqualities
+ ? sdfObject: named<objectqualities>
  EXTENSION-POINT<"object-ext">
 }
 

--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -35,6 +35,11 @@ commonqualities = (
  ? sdfRequired: pointer-list    ; applies to qualities of properties, of data
 )
 
+arraydefinitionqualities = {
+ ? ("minItems" .feature "1.2") => number
+ ? ("maxItems" .feature "1.2") => number
+}
+
 affordancequalities = {
  ? sdfProperty: named<propertyqualities> ; Property represents the state of an instance of an object
  ? sdfAction: named<actionqualities>     ; Action is a directive to invoke an application layer verb associated with an object
@@ -52,10 +57,8 @@ thingqualities = {
 ; for single objects, or for arrays of objects (1.2)
 objectqualities = {
  commonqualities
- ? ("minItems" .feature "1.2") => number
- ? ("maxItems" .feature "1.2") => number
- ? sdfProperty: named<propertyqualities>
  affordancequalities
+ arraydefinitionqualities
  EXTENSION-POINT<"object-ext">
 }
 

--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -61,7 +61,6 @@ objectqualities = {
  commonqualities
  affordancequalities
  arraydefinitionqualities
- ? sdfObject: named<objectqualities>
  EXTENSION-POINT<"object-ext">
 }
 

--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -34,10 +34,10 @@ commonqualities = (
  ? sdfRequired: pointer-list    ; applies to qualities of properties, of data
 )
 
-arraydefinitionqualities = {
+arraydefinitionqualities = (
  ? ("minItems" .feature "1.2") => number
  ? ("maxItems" .feature "1.2") => number
-}
+)
 
 affordancequalities = (
  ? sdfProperty: named<propertyqualities> ; Property represents the state of an instance of an object

--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -51,6 +51,8 @@ thingqualities = {
  commonqualities
  ? sdfObject: named<objectqualities>
  ? sdfThing: named<thingqualities>
+ affordancequalities
+ arraydefinitionqualities
  EXTENSION-POINT<"thing-ext">
 }
 

--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -39,13 +39,13 @@ arraydefinitionqualities = {
  ? ("maxItems" .feature "1.2") => number
 }
 
-affordancequalities = {
+affordancequalities = (
  ? sdfProperty: named<propertyqualities> ; Property represents the state of an instance of an object
  ? sdfAction: named<actionqualities>     ; Action is a directive to invoke an application layer verb associated with an object
  ? sdfEvent: named<eventqualities>       ; Event represents an occurrence of something associated with an object
  ? sdfData: named<dataqualities>         ; Data represents a piece of information that can be the
                                          ; state of a property or a parameter to an action or a signal in an event
-}
+)
 
 ; for building hierarchy
 thingqualities = {

--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -6,9 +6,7 @@ sdf-syntax = {
  ? defaultNamespace: text
  ? sdfThing: named<thingqualities>       ; Thing is a composition of objects that work together in some way
  ? sdfObject: named<objectqualities>     ; Object is a set of Properties, Actions, and Events that together perform a particular function
- ? sdfProperty: named<propertyqualities> ; Property represents the state of an instance of an object
- ? sdfAction: named<actionqualities>     ; Action is a directive to invoke an application layer verb associated with an object
- ? sdfEvent: named<eventqualities>       ; Event represents an occurrence of something associated with an object
+ affordancequalities                     ; Includes Properties, Actions, and Events
  ? sdfData: named<dataqualities>         ; Data represents a piece of information that can be the state of a property or a parameter to an action or a signal in an event
  EXTENSION-POINT<"top-ext">
 }
@@ -37,6 +35,12 @@ commonqualities = (
  ? sdfRequired: pointer-list    ; applies to qualities of properties, of data
 )
 
+affordancequalities = {
+ ? sdfProperty: named<propertyqualities> ; Property represents the state of an instance of an object
+ ? sdfAction: named<actionqualities>     ; Action is a directive to invoke an application layer verb associated with an object
+ ? sdfEvent: named<eventqualities>       ; Event represents an occurrence of something associated with an object
+}
+
 ; for building hierarchy
 thingqualities = {
  commonqualities
@@ -51,9 +55,7 @@ objectqualities = {
  ? ("minItems" .feature "1.2") => number
  ? ("maxItems" .feature "1.2") => number
  ? sdfProperty: named<propertyqualities>
- ? sdfAction: named<actionqualities>
- ? sdfEvent: named<eventqualities>
- ? sdfData: named<dataqualities>
+ affordancequalities
  EXTENSION-POINT<"object-ext">
 }
 

--- a/sdf.md
+++ b/sdf.md
@@ -321,7 +321,6 @@ sdfThing --> "0+" sdfProperty : hasProperty
 sdfThing --> "0+" sdfAction : hasAction
 sdfThing --> "0+" sdfEvent : hasEvent
 
-sdfObject --> "0+" sdfObject : hasObject
 sdfObject --> "0+" sdfProperty : hasProperty
 sdfObject --> "0+" sdfAction : hasAction
 sdfObject --> "0+" sdfEvent : hasEvent
@@ -1064,7 +1063,6 @@ quality is absent.
 | Quality     | Type      | Description                                                              |
 |-------------+-----------+--------------------------------------------------------------------------|
 | (common)    |           | {{common-qualities}}                                                     |
-| sdfObject   | object    | zero or more named nested object definitions for this object             |
 | sdfProperty | property  | zero or more named property definitions for this object                  |
 | sdfAction   | action    | zero or more named action definitions for this object                    |
 | sdfEvent    | event     | zero or more named event definitions for this object                     |

--- a/sdf.md
+++ b/sdf.md
@@ -1207,9 +1207,14 @@ consumption there is no conflict with the intended goal.
 
 ## sdfThing
 
-An sdfThing is a set of declarations and qualities that may be part of a more complex model. For example, the object declarations that make up the definition of a single socket of an outlet strip could be encapsulated in an sdfThing, and the socket-thing itself could be used in a declaration in the sdfThing definition for the outlet strip.
+An sdfThing is a set of declarations and qualities that may be part of a more complex model. For example, the object declarations that make up the definition of a single socket of an outlet strip could be encapsulated in an sdfThing, and the socket-thing itself could be used in a declaration in the sdfThing definition for the outlet strip
+(see {{exa-sdfthing-outlet-strip}} in {outlet-strip-example}} for an example SDF model).
 
 sdfThing definitions carry semantic meaning, such as a defined refrigerator compartment and a defined freezer compartment, making up a combination refrigerator-freezer product.
+An `sdfThing` can also contain Interaction Affordances and sdfData itself, such
+as a status (on/off) for the refrigerator-freezer as a whole (see
+{{exa-sdfthing-fridge-freezer}} in {{fridge-freezer-example}} for an example SDF
+model illustrating these aspects).
 
 An sdfThing may be composed of sdfObjects and other sdfThings.
 
@@ -1528,6 +1533,80 @@ applies on export.
 
 TBD: add any useful implementation notes we can find for other
 ecosystems that use JSO.
+
+# Composition Examples {#composition-examples}
+
+This appendix contains two examples illustrating different composition approaches
+using the `sdfThing` quality.
+
+## Outlet Strip Example {#outlet-strip-example}
+
+~~~
+{
+  "sdfThing": {
+    "outlet-strip" : {
+      "label": "An outlet Strip",
+      "description": "Contains a number of Sockets",
+      "sdfObject": {
+        "socket": {
+          "label": "An array of sockets in the outlet strip",
+          "minItems": 2,
+          "maxItems": 10
+        }
+      }
+    }
+  }
+}
+~~~
+{: #exa-sdfthing-outlet-strip}
+
+## Refrigerator-Freezer Example {#fridge-freezer-example}
+
+~~~
+{
+  "sdfThing": {
+    "refrigerator-freezer" : {
+      "label": "A refrigerator combined with a freezer",
+      "sdfProperty": {
+        "status": {
+          "type": "boolean",
+          "label": {
+            "Indicates if the refrigerator-freezer combination is powered"
+          }
+        }
+      },
+      "sdfObject": {
+        "refrigerator": {
+          "label": "A refrigerator compartment",
+          "sdfProperty": {
+            "temperature": {
+              "sdfRef": "#/sdfProproperty/temperature",
+              "maximum": 8
+            }
+          }
+        },
+        "freezer": {
+          "label": "A freezer compartment",
+          "sdfProperty": {
+            "temperature": {
+              "sdfRef": "#/sdfProproperty/temperature",
+              "maximum": -6
+            }
+          }
+        }
+      },
+    }
+  },
+  "sdfProperty": {
+    "temperature": {
+      "label": "The temperature for this compartment",
+      "type": "integer",
+      "unit": "C"
+    }
+  }
+}
+~~~
+{: #exa-sdfthing-fridge-freezer}
 
 # Acknowledgements
 {: numbered="no"}

--- a/sdf.md
+++ b/sdf.md
@@ -204,7 +204,9 @@ Event:
 
 Object:
 : A grouping of Property, Action, and Event definitions; the main
-  "atom" of reusable semantics for model construction.  (Note that
+  "atom" of reusable semantics for model construction. Objects are
+  similar to Things but do not allow nesting, i. e. they cannot contain
+  other Objects or Things. (Note that
   JSON maps are often called JSON objects due to JSON's JavaScript
   heritage; in this document, the
   term Object is specifically reserved for the above grouping, even if
@@ -487,6 +489,10 @@ and requirements.
 
 Back at the top level, the `sdfThing` groups enables definition of models for
 complex devices that will use one or more `sdfObject` definitions.
+`sdfThing` groups, however, also allow for including interaction
+affordances, `sdfData`, as well as `minItems` and `maxItems` qualities.
+Therefore, they can be seen as a superset of `sdfObject` groups, additionally
+allowing for composition.
 
 A definition in an `sdfThing` group can refine the metadata of the definitions it
 is composed from: other definitions in `sdfThing` groups definitions in `sdfObject` groups.

--- a/sdf.md
+++ b/sdf.md
@@ -317,7 +317,11 @@ Things which are illustrated in {{fig-class-2}}.
 ~~~ plantuml-utxt
 sdfThing --> "0+" sdfObject : hasObject
 sdfThing --> "0+" sdfThing : hasThing
+sdfThing --> "0+" sdfProperty : hasProperty
+sdfThing --> "0+" sdfAction : hasAction
+sdfThing --> "0+" sdfEvent : hasEvent
 
+sdfObject --> "0+" sdfObject : hasObject
 sdfObject --> "0+" sdfProperty : hasProperty
 sdfObject --> "0+" sdfAction : hasAction
 sdfObject --> "0+" sdfEvent : hasEvent
@@ -1060,6 +1064,7 @@ quality is absent.
 | Quality     | Type      | Description                                                              |
 |-------------+-----------+--------------------------------------------------------------------------|
 | (common)    |           | {{common-qualities}}                                                     |
+| sdfObject   | object    | zero or more named nested object definitions for this object             |
 | sdfProperty | property  | zero or more named property definitions for this object                  |
 | sdfAction   | action    | zero or more named action definitions for this object                    |
 | sdfEvent    | event     | zero or more named event definitions for this object                     |
@@ -1212,11 +1217,17 @@ An sdfThing may be composed of sdfObjects and other sdfThings.
 
 The qualities of sdfThing are shown in {{sdfthingqual}}.
 
-| Quality   | Type   | Description          |
-|-----------|--------|----------------------|
-| (common)  |        | {{common-qualities}} |
-| sdfThing  | thing  |                      |
-| sdfObject | object |                      |
+| Quality     | Type      | Description                                                              |
+|-------------|-----------|--------------------------------------------------------------------------|
+| (common)    |           | {{common-qualities}}                                                     |
+| sdfThing    | thing     |                                                                          |
+| sdfObject   | object    |                                                                          |
+| sdfProperty | property  | zero or more named property definitions for this thing                   |
+| sdfAction   | action    | zero or more named action definitions for this thing                     |
+| sdfEvent    | event     | zero or more named event definitions for this thing                      |
+| sdfData     | named-sdq | zero or more named data type definitions that might be used in the above |
+| minItems    | number    | (array) Minimum number of sdfThing instances in array                    |
+| maxItems    | number    | (array) Maximum number of sdfThing instances in array                    |
 {: #sdfthingqual title="Qualities of sdfThing"}
 
 


### PR DESCRIPTION
This PR illustrates the alternative approach I described in the comments of #66. Here, the main changes made are the addition of

1. affordances and `sdfData` as well as `minItems` and `maxItems` to `sdfThing`
2. ~~nesting capabilities to `sdfObject`~~.

Note that `sdfObject` does not include `sdfThing` here, so the two definitions are not syntactically equivalent in this PR. I thought that having `sdfThing`s inside of `sdfObject`s does not make that much sense semantically, but I am looking forward to discuss this with you. 

In order to avoid additional redundancy, this PR also refactors some of the definitions and creates qualities for affordances as well as minItems and maxItems. The names of these additional qualities can probably be improved.

Edit: Resolves #56, resolves #62  