### PR TITLE
fix sdfData multiplicities in UML diagram

### DIFF
--- a/sdf.md
+++ b/sdf.md
@@ -319,10 +319,10 @@ sdfObject --> "0+" sdfProperty : hasProperty
 sdfObject --> "0+" sdfAction : hasAction
 sdfObject --> "0+" sdfEvent : hasEvent
 
-sdfAction --> "1+" sdfData : hasInputData
+sdfAction --> "0+" sdfData : hasInputData
 sdfAction --> "0+" sdfData : hasOutputData
 
-sdfEvent --> "1+" sdfData : hasOutputData
+sdfEvent --> "0+" sdfData : hasOutputData
 
 sdfProperty --> "1" sdfData : isInstanceOf
 


### PR DESCRIPTION
Having a closer look on the UML diagram in the document, I noticed that the multiplicities of `sdfInputData` in `sdfAction` and `sdfOutputData` in `sdfEvent` are currently set to 1+, while both fields are defined as optional in the CDDL schema.

This PR therefore changes the multiplicity of both definitions to 0+, asuming that this is the correct value here. Otherwise the schema might need to be adjusted.