### PR TITLE
Set type of exclusiveMinimum/exclusiveMaximum to number in CDDL schema

### DIFF
--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -132,8 +132,8 @@ jsonschema = (
  ; number/integer constraints
  ? minimum: number
  ? maximum: number
- ? exclusiveMinimum: bool / number      ; jso draft 4/7
- ? exclusiveMaximum: bool / number      ; jso draft 4/7
+ ? exclusiveMinimum: number
+ ? exclusiveMaximum: number
  ? multipleOf: number                   ; ISSUE: Do we need this?
  ; text string constraints
  ? minLength: uint


### PR DESCRIPTION
In the schemas, it is currently still permitted to use a boolean value for `exclusiveMinimum` and `exclusiveMaximum`. Reading through the draft once more, it seems as if this is a leftover from an earlier version that has not been adjusted yet.

This PR provides a simple fix by removing the `bool` types from `exclusiveMinimum` and `exclusiveMaximum` in the `sdf-feature` CDDL file, limiting them to `number`.