### PR TITLE
Add 'modified' quality to the info block

### DIFF
--- a/sdf-feature.cddl
+++ b/sdf-feature.cddl
@@ -15,6 +15,7 @@ sdfinfo = {
  ? version: text
  ? copyright: text
  ? license: text
+ ? modified: modified-date-time
  EXTENSION-POINT<"info-ext">
 }
 
@@ -167,3 +168,26 @@ jsonschema = (
      EXTENSION-POINT<"items-ext">
    }
 )
+
+modified-date-time = text .abnf modified-dt-abnf
+modified-dt-abnf = "modified-dt" .det rfc3339z
+
+; RFC 3339 sans time-numoffset, slightly condensed
+rfc3339z = '
+   date-fullyear   = 4DIGIT
+   date-month      = 2DIGIT  ; 01-12
+   date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
+                             ; month/year
+   time-hour       = 2DIGIT  ; 00-23
+   time-minute     = 2DIGIT  ; 00-59
+   time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap sec
+                             ; rules
+   time-secfrac    = "." 1*DIGIT
+   DIGIT           =  %x30-39 ; 0-9
+
+   partial-time    = time-hour ":" time-minute ":" time-second
+                     [time-secfrac]
+   full-date       = date-fullyear "-" date-month "-" date-mday
+
+   modified-dt     = full-date ["T" partial-time "Z"]
+'

--- a/sdf.md
+++ b/sdf.md
@@ -586,6 +586,7 @@ Qualities of the information block are shown in {{infoblockqual}}.
 |-----------|--------|----------|-------------------------------------------------------------|
 | title     | string | no       | A short summary to be displayed in search results, etc.     |
 | version   | string | no       | The incremental version of the definition                   |
+| modified  | string | no       | Time of the latest modification                             |
 | copyright | string | no       | Link to text or embedded text containing a copyright notice |
 | license   | string | no       | Link to text or embedded text containing license terms      |
 {: #infoblockqual title="Qualities of the Information Block"}
@@ -595,6 +596,8 @@ The version is RECOMMENDED to be lexicographically increasing over the life of a
 This is easily achieved by following the convention to start the version with an {{RFC3339}} `date-time` or, if new versions are generated less frequently than once a day, just the `full-date` (i.e., YYYY-MM-DD); in many cases, that will be all that is needed (see {{example1}} for an example).
 This specification does not give a strict definition for the format of the version string but each using system or organization should define internal structure and semantics to the level needed for their use.
 If no further details are provided, a `date-time` or `full-date` in this field can be assumed to indicate the latest update time of the definitions in the file.
+
+The modified quality can be used with a value using {{RFC3339}} `date-time` or `full-date` format to express time of the latest modification of the definitions.
 
 The license string is preferably either a URI that points to a web page with an unambiguous definition of the license, or an {{SPDX}} license identifier.
 (For models to be handled by the One Data Model liaison group, this will typically be "BSD-3-Clause".)

--- a/sdf.md
+++ b/sdf.md
@@ -597,7 +597,7 @@ This is easily achieved by following the convention to start the version with an
 This specification does not give a strict definition for the format of the version string but each using system or organization should define internal structure and semantics to the level needed for their use.
 If no further details are provided, a `date-time` or `full-date` in this field can be assumed to indicate the latest update time of the definitions in the file.
 
-The modified quality can be used with a value using {{RFC3339}} `date-time` or `full-date` format to express time of the latest modification of the definitions.
+The modified quality can be used with a value using {{RFC3339}} `date-time` (with `Z` for time-zone) or `full-date` format to express time of the latest revision of the definitions.
 
 The license string is preferably either a URI that points to a web page with an unambiguous definition of the license, or an {{SPDX}} license identifier.
 (For models to be handled by the One Data Model liaison group, this will typically be "BSD-3-Clause".)


### PR DESCRIPTION
Fixes #29 

Decided, based on the discussion in the hackathon of IETF 116, to leave out the `created` quality since the semantics of that are not very clear. 

Considered adding text that if the version field uses the RFC 3339 format, that can be considered as the value of the `created` quality, but that probably has many corner cases where this rule would not apply, so left that out.

Not adding "tool info" (discussed on the [ASDF list](https://mailarchive.ietf.org/arch/msg/asdf/neZKbsU_qcmuKVFNLIvVXFvnHJc/)). That is probably best expressed using `$comment`