### PR TITLE
Fix diff URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Internet-Draft for the One Data Model Simple Definition Format (SDF)
 
 [sdftype-html]: https://raw.githack.com/ietf-wg-asdf/SDF/sdftype/sdf.html
 [sdftype-diff]: https://tools.ietf.org/rfcdiff?url1=https://raw.githubusercontent.com/ietf-wg-asdf/SDF/master/sdf.txt&url2=https://raw.githubusercontent.com/ietf-wg-asdf/SDF/sdftype/sdf.txt
-[I-D-01-master-diff]: https://tools.ietf.org/rfcdiff?url1=draft-ietf-asdf-sdf.txt&url2=https://raw.githack.com/ietf-wg-asdf/SDF/master/sdf.txt
+[I-D-01-master-diff]: https://author-tools.ietf.org/iddiff?url1=draft-ietf-asdf-sdf.txt&url2=https://raw.githubusercontent.com/ietf-wg-asdf/SDF/master/sdf.txt


### PR DESCRIPTION
With the current URL the response is this 
<img width="421" alt="image" src="https://github.com/ietf-wg-asdf/SDF/assets/31825085/a4f0945b-7d74-4513-a7b2-370b747f135d">
This PR should fix that! :octocat: 