### PR TITLE
Add sdfProperty extension point to CDDL schema

### DIFF
--- a/sdf-framework.cddl
+++ b/sdf-framework.cddl
@@ -132,6 +132,7 @@ propertyqualities = {
  ? readable: bool
  ? writable: bool
  ~dataqualities
+ EXTENSION-POINT<"property-ext">
 }
 
 allowed-types = number / text / bool / null


### PR DESCRIPTION
As discussed on the mailing list, this PR proposes a small fix to the sdf-framework CDDL file, which adds a potentially missing extension point for `sdfProperty`.

As without this extension point, it isn't possible to define extensions that are only applicable to interaction affordances (instead of also affecting all instances of `sdfData`), I would consider this a fix that could be added to the document alongside the fixes made in #187 and #188.

However, I can also understand the arguments made by @cabo and @akeranen for not taking this change into account for a last-minute update. In any case, due to the other PRs, I still wanted to make this proposal as it came up while working on https://github.com/ietf-wg-asdf/sdf-relations/pull/6. Here, I had the feeling that having an extension point for actions and events, but not for properties is a bit counterintuitive, although of course you can cover `sdfProperty` by extending `sdfData`.